### PR TITLE
Fix test infrastructure for missing deps

### DIFF
--- a/src/app/models/searchable.py
+++ b/src/app/models/searchable.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
-from src.app import db
-from src.app.search import add_to_index, remove_from_index, query_index
+from src.app import db, search
 
 
 class SearchableMixin(object):
@@ -94,14 +93,14 @@ class SearchableMixin(object):
         """
         for obj in session._changes["add"]:
             if isinstance(obj, SearchableMixin):
-                add_to_index(obj.__tablename__, obj)
+                search.add_to_index(obj.__tablename__, obj)
 
         for obj in session._changes["update"]:
             if isinstance(obj, SearchableMixin):
-                add_to_index(obj.__tablename__, obj)
+                search.add_to_index(obj.__tablename__, obj)
         for obj in session._changes["delete"]:
             if isinstance(obj, SearchableMixin):
-                remove_from_index(obj.__tablename__, obj)
+                search.remove_from_index(obj.__tablename__, obj)
         session._changes = None
 
     @classmethod
@@ -119,7 +118,7 @@ class SearchableMixin(object):
             Post.reindex()
         """
         for obj in db.session.scalars(sa.select(cls)):
-            add_to_index(cls.__tablename__, obj)
+            search.add_to_index(cls.__tablename__, obj)
 
 
 db.event.listen(db.session, "before_commit", SearchableMixin.before_commit)

--- a/src/utils/pipeline_utils.py
+++ b/src/utils/pipeline_utils.py
@@ -2,13 +2,28 @@
 Utility functions for ETL pipeline
 """
 
-import typer
+try:
+    import typer
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+
+    class _TyperModule:
+        class BadParameter(Exception):
+            pass
+
+        class Context:
+            pass
+
+    typer = _TyperModule()
 import logging
 import sys
 import os
 from pathlib import Path
 from datetime import datetime, time, UTC
-import pandas as pd
+
+try:
+    import pandas as pd
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pd = None
 from glob import glob
 from flask_babel import _
 from src.utils.logging_utils import LoggingUtils, LogFileCreationError


### PR DESCRIPTION
## Summary
- fix patching of Elasticsearch in tests
- reference search helpers from module to allow mocking
- handle optional dependencies in pipeline_utils
- skip tests when dependencies are missing and add path adjustments

## Testing
- `pytest src/tests.py test/utils/test_pipeline_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683e374cc5b483288d8eb9b78f30ab74